### PR TITLE
saving fix

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -190,14 +190,14 @@ class ActiveRecord extends BaseActiveRecord
         if (!isset($data[$attributes[$pkName]])) {
             throw new InvalidConfigException("'{$pkName}' value '{$values[$pkName]}' does not exist.");
         }
-        $data[$attributes[$pkName]] = $values;
-        $db->writeData($dataFileName, $data);
 
         $changedAttributes = [];
         foreach ($values as $name => $value) {
+            $data[$attributes[$pkName]][$name] = $value;
             $changedAttributes[$name] = $this->getOldAttribute($name);
             $this->setOldAttribute($name, $value);
         }
+        $db->writeData($dataFileName, $data);
         $this->afterSave(false, $changedAttributes);
 
         return 1;

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -155,6 +155,7 @@ class ActiveRecordTest extends TestCase
         $this->assertFalse($record->isNewRecord);
         $record2 = Customer::findOne($record->id);
         $this->assertEquals(9, $record2->statusId);
+        $this->assertEquals($record->attributes, $record2->attributes);
 
         // updateAll
         $pk = ['id' => $record->id];


### PR DESCRIPTION
Hello!
I found a small bug in `updateInternal()` method. It losed some fields because `getDirtyAttributes()` returns only updated values.

**Case:**
I have a model `User` with fields id, name, password.

``` php
$user = new User;
$user->id = 5;
$user->name = 'test';
$user->password = 'test_password';
$user->save();

$user = User::findOne(5);
$user->password = 'new password';
$user->save();
```

Here I have only id and password in db file.
