### PR TITLE
resetting opcache after save

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -165,15 +165,20 @@ class Connection extends Component
     {
         $this->getFileManager()->writeData($this->composeFullFileName($name), $data);
         unset($this->dataCache[$name]);
+        if (ini_get('opcache.enable') == '1') {
+            opcache_invalidate($this->composeFullFileName($name, true), true);
+        }
     }
 
     /**
      * Composes data file name with full path, but without extension.
      * @param string $name data file self name.
+     * @param bool $withExtension whether to return the file name with extension.
      * @return string data file name without extension.
      */
-    protected function composeFullFileName($name)
+    protected function composeFullFileName($name, $withExtension = false)
     {
-        return Yii::getAlias($this->path) . DIRECTORY_SEPARATOR . $name;
+        return Yii::getAlias($this->path). DIRECTORY_SEPARATOR . $name
+            . ($withExtension === true ? '.' . $this->getFileManager()->fileExtension : '');
     }
 }


### PR DESCRIPTION
Hello!
I found the next problem. Connection returns an old data after save. It occurs if opcache is enabled.

**Case**
I have this code:

``` php
public function actionEdit($id)
{
    $model = $this->findModel($id);
    if ($model->load(Yii::$app->request->post()) && $model->save()) {
        return $this->redirect(['edit', 'id' => $model->id]);
    } else {
        return $this->render(
            'edit',
            [
                'model' => $model,
            ]
        );
    }
}
```
1. I fill a form with new field values.
2. I press a `save` button.
3. I get same form with old values but file keeps an actual (new) data.
