### PR TITLE
Update ActiveRecord.php

### DIFF
--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -253,7 +253,7 @@ class ActiveRecord extends BaseActiveRecord
     /**
      * @inheritdoc
      */
-    public static function deleteAll($condition = null)
+    public static function deleteAll($condition = null, , $params = [])
     {
         $count = 0;
         $records = static::findAll($condition);


### PR DESCRIPTION
PHP Compile Error – yii\base\ErrorException

Declaration of yii2tech\filedb\ActiveRecord::deleteAll($condition = NULL) must be compatible with yii\db\BaseActiveRecord::deleteAll($condition = '', $params = Array)